### PR TITLE
update to use @vue/composition-api package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,20 +8,20 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@vue/composition-api": "^0.2.1",
     "case": "^1.6.1",
     "js-levenshtein": "^1.1.6",
     "prettier": "^1.18.2",
     "recast": "^0.18.1",
     "stemmer": "^1.0.4",
     "vue": "^2.5.22",
-    "vue-function-api": "^1.0.3",
     "vue-monaco": "^0.3.2"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.6.0",
     "@vue/cli-plugin-eslint": "^3.6.0",
-    "@vue/eslint-config-standard": "^4.0.0",
     "@vue/cli-service": "^3.6.0",
+    "@vue/eslint-config-standard": "^4.0.0",
     "babel-eslint": "^10.0.1",
     "eslint": "^5.8.0",
     "eslint-plugin-vue": "^5.0.0",

--- a/src/functions/code.js
+++ b/src/functions/code.js
@@ -1,10 +1,10 @@
-import { value, watch } from 'vue-function-api'
+import { ref, watch } from '@vue/composition-api'
 import prettier from 'prettier/standalone'
 import prettierTypescriptParser from 'prettier/parser-typescript'
 import { convertScript } from '@/converter'
 
 export function useStoredCode (storageKey, defaultCode) {
-  const code = value(localStorage.getItem(storageKey) || defaultCode)
+  const code = ref(localStorage.getItem(storageKey) || defaultCode)
 
   watch(code, value => {
     localStorage.setItem(storageKey, value)
@@ -16,8 +16,8 @@ export function useStoredCode (storageKey, defaultCode) {
 }
 
 export function useCodeConverter (code) {
-  const result = value('')
-  const error = value(null)
+  const result = ref('')
+  const error = ref(null)
 
   // Convert code automatically
   watch(code, value => {

--- a/src/functions/windowSize.js
+++ b/src/functions/windowSize.js
@@ -1,10 +1,10 @@
-import { onCreated, onDestroyed } from 'vue-function-api'
+import { onBeforeMount, onUnmounted } from '@vue/composition-api'
 
 export function onWindowResize (callback) {
-  onCreated(() => {
+  onBeforeMount(() => {
     window.addEventListener('resize', callback)
   })
-  onDestroyed(() => {
+  onUnmounted(() => {
     window.removeEventListener('resize', callback)
   })
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,10 @@
 import Vue from 'vue'
-import { plugin } from 'vue-function-api'
+import CompositionApi from '@vue/composition-api'
 import App from './App.vue'
 
 Vue.config.productionTip = false
 
-Vue.use(plugin)
+Vue.use(CompositionApi)
 
 new Vue({
   render: h => h(App),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1001,6 +1001,13 @@
     source-map "~0.6.1"
     vue-template-es2015-compiler "^1.9.0"
 
+"@vue/composition-api@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.2.1.tgz#d6b4327b308ac474982536f86bf44dd00271742d"
+  integrity sha512-eRmvToKbNjFXYyuFZ8e9KUcBXwDj0PQR1ngZP4u3R2jR9yjIbvgEsj7IKoddSKYiEkMttn+JiaSKX7n+REQBBw==
+  dependencies:
+    tslib "^1.9.3"
+
 "@vue/eslint-config-standard@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@vue/eslint-config-standard/-/eslint-config-standard-4.0.0.tgz#6be447ee674e3b0f733c584098fd9a22e6d76fcd"
@@ -8085,13 +8092,6 @@ vue-eslint-parser@^5.0.0:
     espree "^4.1.0"
     esquery "^1.0.1"
     lodash "^4.17.11"
-
-vue-function-api@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/vue-function-api/-/vue-function-api-1.0.4.tgz#3914434b3831aeb82e269197bf9b975a741f6a1f"
-  integrity sha512-JH/7YLmRrcnP+BAjIJbL7orU0Ief76kvK6s3LIp0uiOR3pBa9nkpQWWJxaoN+r1CHQsC2794+FSpl7/d4wl3AA==
-  dependencies:
-    tslib "^1.9.3"
 
 vue-hot-reload-api@^2.3.0:
   version "2.3.3"


### PR DESCRIPTION
replace [vue-function-api](https://www.npmjs.com/package/vue-function-api) package for [composition-api](https://www.npmjs.com/package/@vue/composition-api)

with the changes applied: https://github.com/vuejs/rfcs/pull/78#issue-308260020