### PR TITLE
import and identifier, value to ref

### DIFF
--- a/src/converter/index.js
+++ b/src/converter/index.js
@@ -88,7 +88,7 @@ export function convertScript (script, {
     }))
     if (dataProperties.length) {
       if (dataProperties.some(p => !p.state)) {
-        newImports.vue.push('value')
+        newImports.vue.push('ref')
       }
       if (dataProperties.some(p => p.state)) {
         newImports.vue.push('state')
@@ -99,7 +99,7 @@ export function convertScript (script, {
             builders.variableDeclarator(
               builders.identifier(property.name),
               builders.callExpression(
-                builders.identifier(property.state ? 'state' : 'value'),
+                builders.identifier(property.state ? 'state' : 'ref'),
                 [property.value],
               ),
             ),

--- a/src/converter/index.js
+++ b/src/converter/index.js
@@ -91,7 +91,7 @@ export function convertScript (script, {
         newImports.vue.push('ref')
       }
       if (dataProperties.some(p => p.state)) {
-        newImports.vue.push('state')
+        newImports.vue.push('reactive')
       }
       for (const property of dataProperties) {
         setupFn.body.body.push(
@@ -99,7 +99,7 @@ export function convertScript (script, {
             builders.variableDeclarator(
               builders.identifier(property.name),
               builders.callExpression(
-                builders.identifier(property.state ? 'state' : 'ref'),
+                builders.identifier(property.state ? 'reactive' : 'ref'),
                 [property.value],
               ),
             ),


### PR DESCRIPTION
Vue.js 2 original script

```js
export default {
  data () {
    return {
      message: 'hello world',
      counter: 0
    }
  },

  computed: {
    reverseMessage () {
      return this.message.split('').reverse().join('')
    }
  },
  methods: {
    increase() {
      this.counter++
    }
  }
}
```

master branch's converter covert data to `value` but I can't find `value` in RFC but `ref` is here.

```js
import { value, computed } from 'vue'

export default {
  setup() {
    // Message
    const message = value('hello world') // !!!: It failed value is not function

    const reverseMessage = computed(() => {
      return message.value
        .split('')
        .reverse()
        .join('')
    })

    // Misc
    const counter = value(0)

    function increase() {
      counter.value++
    }

    return {
      message,
      counter,
      reverseMessage,
      increase
    }
  }
}
```

Should be this

```js
import { ref, computed } from 'vue'

export default {
  setup() {
    // Message
    const message = ref('hello world')

    const reverseMessage = computed(() => {
      return message.value
        .split('')
        .reverse()
        .join('')
    })

    // Misc
    const counter = ref(0)

    function increase() {
      counter.value++
    }

    return {
      message,
      counter,
      reverseMessage,
      increase
    }
  }
}
```

You can check this codesandbox in Tester.vue

https://codesandbox.io/s/vue-composition-api-example-fseyd?fontsize=14
and I use `@vue/composition-api` same as  https://github.com/vuejs/function-api-converter/pull/8